### PR TITLE
refactor: fix missing types and path imports

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,5 @@
+import type { CSSProperties } from 'react';
+
 export const formatMonth = (month: number) => {
   return String(month).padStart(2, '0');
 }
@@ -9,7 +11,7 @@ export const isUUID = (uuid: string): boolean => {
 };
 
 // 배경 이미지 스타일 반환
-export const setBackgroundImage = (url: string): React.CSSProperties => {
+export const setBackgroundImage = (url: string): CSSProperties => {
   return {
     backgroundImage: `url(${url})`,
   };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
-import path from 'node:path';
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import path from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -8,6 +8,6 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
-    }    
+    }
   },
-})
+});


### PR DESCRIPTION
## Summary
- import React CSSProperties and use without namespace
- use Node path module without node: prefix in Vite config

## Testing
- `npm run build` *(fails: TS2307 Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68936d3b0e1c832dba06f5715d709bfa