### PR TITLE
Rename updateAt to updatedAt across reservation modules

### DIFF
--- a/src/components/mobiles/ReserveList.tsx
+++ b/src/components/mobiles/ReserveList.tsx
@@ -88,7 +88,7 @@ export default function ReserveList({ listType }: Props) {
               </div>
               <div className="w-4/12 items-center flex flex-col">
                 <div className="text-sm">{getMobileNum(data.phoneNum)}</div>
-                <div className="text-secondary-700 text-xs">{prettyDate(data.updateAt)}</div>
+                <div className="text-secondary-700 text-xs">{prettyDate(data.updatedAt)}</div>
               </div>
               <div className="w-3/12 flex justify-center gap-1.5">
                 <div

--- a/src/components/modals/MessageModal.tsx
+++ b/src/components/modals/MessageModal.tsx
@@ -64,8 +64,8 @@ const MessageModal: React.FC = () => {
                   <td><span>{messageInfo.phoneNum}</span></td>
                   <td>
                     <span>
-                      {messageInfo.updateAt
-                        ? `${prettyDate(messageInfo.updateAt)} 20:30`
+                      {messageInfo.updatedAt
+                        ? `${prettyDate(messageInfo.updatedAt)} 20:30`
                         : '-'}
                     </span>
                   </td>

--- a/src/pages/tablings/TablingPage.tsx
+++ b/src/pages/tablings/TablingPage.tsx
@@ -19,7 +19,7 @@ interface ReserveItem {
   reservationNum: string | number;
   personCount: number;
   phoneNum: string;
-  updateAt?: string;
+  updatedAt?: string;
 }
 
 type ReserveType = 'reserve' | 'cancel' | 'complete';
@@ -470,7 +470,7 @@ const TablingPage: React.FC = () => {
                                           {prettyPhoneNumber(reserve.phoneNum)}
                                       </td>
                                       <td className='px-4 py-4 text-center'>
-                                          {prettyDate(reserve.updateAt)} 20:30
+                                          {prettyDate(reserve.updatedAt)} 20:30
                                       </td>
                                       {selectOrderType !== 'complete' && (
                                           <td className='px-[2px] py-4 lg:px-1 w-10 lg:w-12'>

--- a/src/stores/reserve/messageModal.ts
+++ b/src/stores/reserve/messageModal.ts
@@ -5,7 +5,7 @@ export interface MessageInfo {
   reservationNum: number | string;
   userName: string;
   phoneNum: string;
-  updateAt: string;
+  updatedAt: string;
 }
 
 interface MessageModalStore {

--- a/src/stores/reserve/reserveList.ts
+++ b/src/stores/reserve/reserveList.ts
@@ -2,12 +2,12 @@ import { create } from 'zustand';
 import { alertError, api } from '@/utils/api';
 
 interface ReserveItem {
-  reservationId: string; 
+  reservationId: string;
   userName: string;
   reservationNum: string | number;
   personCount: number;
   phoneNum: string;
-  updateAt: string;
+  updatedAt: string;
 }
 
 type ReserveType = 'reserve' | 'cancel' | 'complete';


### PR DESCRIPTION
## Summary
- standardize reservation timestamp field as `updatedAt` across stores and UI
- update message modal and mobile reserve list to use `updatedAt`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find type definition files such as 'react')*

------
https://chatgpt.com/codex/tasks/task_e_689372d9966c832da51c987bc3875bf5