### PR TITLE
feat: navigate after alert

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -46,16 +46,26 @@ export const imagesUpload = async (files: FileList | File[]): Promise<string[]> 
 };
 
 // 에러 알림 및 이동
-export const alertError = (errorMessage: string | unknown) => {
-  // const navigate = useNavigate();
-  alert(`${errorMessage}, 관리자에게 문의하세요.`);
+export const alertError = (
+  error: unknown,
+  navigate?: (path: string) => void
+): void => {
+  const message =
+    typeof error === 'string'
+      ? error
+      : error instanceof Error
+        ? error.message
+        : String(error);
 
-  if (true) {
-    const currentPath = window.location.pathname;
-    if (currentPath.includes('mobile')) {
-      // navigate('/mobile/main');
-    } else {
-      // navigate('/');
-    }
+  alert(`${message}, 관리자에게 문의하세요.`);
+
+  const redirectPath = window.location.pathname.includes('mobile')
+    ? '/mobile/main'
+    : '/';
+
+  if (navigate) {
+    navigate(redirectPath);
+  } else {
+    window.location.assign(redirectPath);
   }
 };


### PR DESCRIPTION
## Summary
- handle error alerts with redirect

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689372de4bbc832dbdc7d4892fd66abb