### PR TITLE
refactor: navigate to booth detail with spa

### DIFF
--- a/src/stores/booths/boothList.ts
+++ b/src/stores/booths/boothList.ts
@@ -2,8 +2,12 @@ import { create } from 'zustand';
 import { api, alertError } from '@/utils/api';
 import { ADMIN_CATEGORY } from '@/constants/constant';
 import { BoothListState } from '@/types/booths/booth.types';
+import { useNavigate } from 'react-router-dom';
 
-export const useBoothList = create<BoothListState>((set, get) => ({
+export const useBoothList = create<BoothListState>((set, get) => {
+  const navigate = useNavigate();
+
+  return {
   boothList: [],
 
   getAllBoothList: async () => {
@@ -36,7 +40,7 @@ export const useBoothList = create<BoothListState>((set, get) => ({
   },
 
   handleClickBoothDetail: (boothId: string) => {
-    window.location.href = `/booth/${boothId}`;
+    navigate(`/booth/${boothId}`);
   },
 
   updateBoothOpen: async ({ boothId, isOpen, adminCategory }) => {
@@ -102,4 +106,5 @@ export const useBoothList = create<BoothListState>((set, get) => ({
       console.error(error);
     }
   },
-}));
+};
+});


### PR DESCRIPTION
## Summary
- replace window navigation with React Router navigation in booth list store

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68937307e348832dade105816cf0ad4e