### PR TITLE
refactor: consolidate order cooking refresh effect

### DIFF
--- a/src/pages/orders/OrderCookingPage.tsx
+++ b/src/pages/orders/OrderCookingPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useCookingOrder } from '@/stores/orders/cookingOrder';
 import IconNotFound from '@/components/icons/IconNotFound';
 import OrderCookingCard from '@/components/orders/OrderCookingCard';
@@ -13,31 +13,17 @@ const OrderCookingPage: React.FC = () => {
     getCookingOrderList,
   } = useCookingOrder();
 
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
-
   useEffect(() => {
     if (!boothId) return;
 
     getCookingOrderList({ boothId, date: nowDate });
 
-    intervalRef.current = setInterval(() => {
-      getCookingOrderList({ boothId, date: nowDate });
-    }, 3000);
-
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-      }
-    };
-  }, [boothId, nowDate]);
-
-  useEffect(() => {
     const interval = setInterval(() => {
       getCookingOrderList({ boothId, date: nowDate });
     }, 2000); // 2초 간격으로 서버에서 최신 조리 현황 받아오기
 
     return () => clearInterval(interval);
-  }, []);
+  }, [boothId, nowDate]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- consolidate order refresh polling into one effect with boothId and date dependencies
- clean up polling interval to avoid leaks

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68937308a73c832da66aeae8cfbc1e4c