### PR TITLE
refactor: add booth typings and remove any

### DIFF
--- a/src/pages/booths/BoothDetailPage.tsx
+++ b/src/pages/booths/BoothDetailPage.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from 'react-router-dom';
 import { useParams } from 'react-router-dom';
 import { useUserStore } from '@/stores/logins/userStore';
 import FestinoLogo from '@/components/icons/FestinoLogo';
+import { Menu } from '@/types/booths/booth.types';
 
 const BoothDetailPage: React.FC = () => {
   const { reset, init, boothInfo, menuList, updateBoothInfo, updateMenuList } = useBoothDetail();
@@ -44,7 +45,7 @@ const BoothDetailPage: React.FC = () => {
     scrollImage('right');
   };
 
-  const handleClickSoldOut = async (menu: any) => {
+  const handleClickSoldOut = async (menu: Menu) => {
     if (isBoothOwner) {
       try {
         const response = await api.put('/admin/menu/sold-out', {

--- a/src/pages/mobiles/MobileRservePage.tsx
+++ b/src/pages/mobiles/MobileRservePage.tsx
@@ -43,7 +43,7 @@ const MobileReservePage: React.FC = () => {
   useEffect(() => {
     const init = async () => {
       await getAllBoothList();
-      const filtered = boothList.filter((booth: any) => booth?.isReservation);
+      const filtered = (boothList as Booth[]).filter((booth: Booth) => booth?.isReservation);
       setReserveBoothList(filtered);
 
       if (isAdmin) {
@@ -54,7 +54,7 @@ const MobileReservePage: React.FC = () => {
         setSelectedBooth(filtered[0]);
       } else {
         if (userOwnBoothId) {
-          const found = filtered.find((booth: any) => booth.boothId === userOwnBoothId);
+          const found = filtered.find((booth: Booth) => booth.boothId === userOwnBoothId);
           if (found) {
             setSelectedBooth(found);
             setBoothInfo(found);

--- a/src/pages/orders/OrderRealTimePage.tsx
+++ b/src/pages/orders/OrderRealTimePage.tsx
@@ -5,7 +5,7 @@ import IconNotFound from '@/components/icons/IconNotFound';
 import { cloneDeep, isEqual } from 'lodash';
 import OrderCard from '@/components/orders/OrderCard';
 import { useNowOrderStore } from '@/stores/orders/nowOrder';
-import { WaitDepositOrder } from '@/types/orders/order.types';
+import { WaitDepositOrder, CookingMenu, FinishOrder } from '@/types/orders/order.types';
 
 const OrderRealTimePage: React.FC = () => {
   const { boothId } = useTableStatusOrder();
@@ -58,7 +58,9 @@ const OrderRealTimePage: React.FC = () => {
     };
   }, [boothId, nowDate]);
 
-  const renderCardSection = (type: string, data: any[]) => {
+  type OrderData = WaitDepositOrder | CookingMenu | FinishOrder;
+
+  const renderCardSection = (type: string, data: OrderData[]) => {
     const bgMap: Record<string, string> = {
       ready: 'bg-danger-600-light-5',
       cooking: 'bg-primary-600-light-5',

--- a/src/types/booths/booth.types.ts
+++ b/src/types/booths/booth.types.ts
@@ -61,7 +61,7 @@ export interface BoothInfo {
   openTime: string;
   closeTime: string;
   boothIntro: string;
-  boothImage: any[];
+  boothImage: string[];
   location: string;
   isCall: boolean;
   isOpen: boolean;


### PR DESCRIPTION
## Summary
- type booths explicitly in mobile reservation page
- use typed Menu for sold-out handler on booth detail page
- strengthen booth image definition and render order cards with typed data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find modules such as 'react')*

------
https://chatgpt.com/codex/tasks/task_e_6893730914dc832d9ef74559c11fad60